### PR TITLE
Change dash to underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Like this.
     'your-custom-setting' => [
       'id' => '{YOUR POST ID}',
       'title' => 'Your custom setting',
-      'block-editor' => true,
+      'block_editor' => true,
     ],
   ],
 ```


### PR DESCRIPTION
All references to settings in `setting-group-block-editor.php` are using `block_editor` as the array key, so it must be just a typo in readme.